### PR TITLE
Remove airbnb title and slogan from react guide.

### DIFF
--- a/src/markdown/react-guide.md
+++ b/src/markdown/react-guide.md
@@ -1,7 +1,3 @@
-# Airbnb React/JSX Style Guide
-
-*A mostly reasonable approach to React and JSX*
-
 ## Table of Contents
 
   1. [Basic Rules](#basic-rules)


### PR DESCRIPTION
Don't want any refs to AirBnb :)